### PR TITLE
Add 0 value to MIDI note dropdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ instance.prototype.MIDI_inputs_list = [];
 instance.prototype.MIDI_outputs_list = [];
 
 instance.prototype.MIDI_notes = [
+	{id: 0, label: '0 - unassigned'},
 	{id: 1, label: '1 - unassigned'},
 	{id: 2, label: '2 - unassigned'},
 	{id: 3, label: '3 - unassigned'},


### PR DESCRIPTION
### Proposed Changes

Valid MIDI notes are 0-127, but the dropdown only had options for 1-127. This PR adds 0 as an option.

*Note: There is currently a bug in midi-relay preventing note 0 from being sent correctly (https://github.com/josephdadams/midi-relay/issues/5), ~~but I will have a PR for that ready soon~~ PR submitted (https://github.com/josephdadams/midi-relay/pull/7).*