### PR TITLE
FEATURE: Custom max number of keys on the surface

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -152,7 +152,7 @@ module.exports = {
 							//send the satelite surface key press, if needed
 							if (self.config.useAsSurface) {
 								if (midiObj.midicommand == 'noteon' || midiObj.midicommand == 'noteoff') {
-									if (midiObj.note >= self.config.noteOffset && midiObj.note <= self.config.noteOffset + 31) {
+									if (midiObj.note >= self.config.noteOffset && midiObj.note <= self.config.noteOffset + 32) {
 										let keyState = midiObj.midicommand == 'noteon' ? 'true' : 'false';
 										let keyNumber = midiObj.note - self.config.noteOffset; //ok to not add 1, because it it zero based anyway
 										if (self.config.useAllChannelsAsSurfaces) {

--- a/src/api.js
+++ b/src/api.js
@@ -152,7 +152,7 @@ module.exports = {
 							//send the satelite surface key press, if needed
 							if (self.config.useAsSurface) {
 								if (midiObj.midicommand == 'noteon' || midiObj.midicommand == 'noteoff') {
-									if (midiObj.note >= self.config.noteOffset && midiObj.note <= self.config.noteOffset + 32) {
+									if (midiObj.note >= self.config.noteOffset && midiObj.note <= self.config.noteOffset + self.config.maxKeys-1) {
 										let keyState = midiObj.midicommand == 'noteon' ? 'true' : 'false';
 										let keyNumber = midiObj.note - self.config.noteOffset; //ok to not add 1, because it it zero based anyway
 										if (self.config.useAllChannelsAsSurfaces) {

--- a/src/config.js
+++ b/src/config.js
@@ -145,7 +145,7 @@ module.exports = {
 				width: 2,
 				default: 32,
 				min: 1,
-				max: 256,
+				max: 1024,
 				isVisible: (config) => config.useAsSurface == true,
 			},
 			{

--- a/src/config.js
+++ b/src/config.js
@@ -114,7 +114,7 @@ module.exports = {
 				type: 'checkbox',
 				id: 'useAsSurface',
 				label: 'Use MIDI Feedback as a Companion Satellite Surface',
-				tooltip: 'With this option, the first 32 keys of the channel starting at the note offset will be automatically assigned as surface keys. NoteOn at any velocity will trigger the key, and NoteOff will release it.',
+				tooltip: 'With this option, the first keys of the channel starting at the note offset will be automatically assigned as surface keys. NoteOn at any velocity will trigger the key, and NoteOff will release it.',
 				width: 2,
 				default: false,
 				isVisible: (config) => config.useMidiFeedback == true
@@ -136,6 +136,16 @@ module.exports = {
 				default: 21,
 				min: 0,
 				max: 95,
+				isVisible: (config) => config.useAsSurface == true,
+			},
+			{
+				type: 'number',
+				id: 'maxKeys',
+				label: 'How many keys to use as buttons (>1)',
+				width: 2,
+				default: 32,
+				min: 1,
+				max: 256,
 				isVisible: (config) => config.useAsSurface == true,
 			},
 			{

--- a/src/surface.js
+++ b/src/surface.js
@@ -80,11 +80,11 @@ module.exports = {
 					let productName = 'TechMinistry midi-relay';
 					if (self.config.useAllChannelsAsSurfaces) {
 						for (let i = 1; i <= 16; i++) {
-							self.sendCompanionSatelliteCommand(`ADD-DEVICE DEVICEID=${self.DEVICEID}-ch${i.toString().padStart(2, '0')} PRODUCT_NAME="${productName}" BITMAPS=false COLORS=false TEXT=false`);
+							self.sendCompanionSatelliteCommand(`ADD-DEVICE DEVICEID=${self.DEVICEID}-ch${i.toString().padStart(2, '0')} PRODUCT_NAME="${productName}" KEYS_TOTAL=${self.config.maxKeys} BITMAPS=false COLORS=false TEXT=false`);
 						}
 					}
 					else {
-						self.sendCompanionSatelliteCommand(`ADD-DEVICE DEVICEID=${self.DEVICEID} PRODUCT_NAME="${productName}" BITMAPS=false COLORS=false TEXT=false`);
+						self.sendCompanionSatelliteCommand(`ADD-DEVICE DEVICEID=${self.DEVICEID} PRODUCT_NAME="${productName}" KEYS_TOTAL=${self.config.maxKeys} BITMAPS=false COLORS=false TEXT=false`);
 					}
 					continue;
 				}


### PR DESCRIPTION
Recently I've tried to map my midi controller, that has almost 60 buttons on it. However, the module defines hardoded limit of 32 midi keys.
As of the 1.5.1 Satellite can have any number of keys above 1, so I request adding a field that allows defining max number of keys for the surface, so bigger sized surfaces can be added as a MIDI Surfaces

https://github.com/bitfocus/companion/wiki/Satellite-API#adding-a-satellite-device